### PR TITLE
Allow handling of .jpg extension in the same way as .jpeg

### DIFF
--- a/postgrid/__init__.py
+++ b/postgrid/__init__.py
@@ -108,6 +108,8 @@ def _request(base, endpoint, method='GET', idempotency_key=None, **kwargs):
                     content_type = 'application/pdf'
                 elif ext == '.png':
                     content_type = 'image/png'
+                elif ext == '.jpg':
+                    content_type = 'image/jpeg'
                 elif ext == '.jpeg':
                     content_type = 'image/jpeg'
                 else:


### PR DESCRIPTION
Some files may come with `.jpg` instead of `.jpeg`. Let's treat them the same way without having to have the user rename them.